### PR TITLE
Add MIT License to repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ryan Wolfslayer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ python3 app.py
 
 - **[docs/TECHNICAL.md](docs/TECHNICAL.md)** - Developer setup, architecture, troubleshooting
 - **[docs/STAKEHOLDER.md](docs/STAKEHOLDER.md)** - Business impact and strategic value
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This PR adds an open source license to the ReelTracker repository, resolving issue #2.

## Changes
- Added LICENSE file with MIT License text
- Updated README.md with license section

## License Selection
The MIT License was chosen because it's:
- Simple and widely understood
- Permissive for both personal and commercial use
- Allows modification and distribution
- Only requires license preservation

Closes #2

Generated with [Claude Code](https://claude.ai/code)